### PR TITLE
Don't throw exception if publishable column does not (yet) exist.

### DIFF
--- a/lib/publishable.rb
+++ b/lib/publishable.rb
@@ -38,9 +38,8 @@ module Publishable
     def publishable(options = {})
       return unless table_exists?
       column_name = (options[:on] || :published).to_sym
-      unless self.columns_hash[column_name.to_s].present?
-        raise ActiveRecord::ConfigurationError, "No '#{column_name}'column available for Publishable column on model #{self.name}"
-      end
+      # silently ignore a missing column - since bombing on a missing column can make re-running migrations very hard
+      return unless self.columns_hash[column_name.to_s].present?
       column_type = self.columns_hash[column_name.to_s].type
 
       if respond_to?(:scope)

--- a/spec/publishable_spec.rb
+++ b/spec/publishable_spec.rb
@@ -264,7 +264,7 @@ describe Publishable do
       }.to raise_error ActiveRecord::ConfigurationError
     end
 
-    it 'should raise a configuration error when the publish column not defined' do
+    it 'should not raise a configuration error when the publish column not defined' do
       expect {
         build_model :post do
           string :title
@@ -274,10 +274,10 @@ describe Publishable do
           extend Publishable
           publishable
         end
-      }.to raise_error ActiveRecord::ConfigurationError
+      }.to_not raise_error
     end
 
-    it 'should raise a configuration error when defined on a missing column' do
+    it 'should not raise a configuration error when defined on a missing column' do
       expect {
         build_model :post do
           string :title
@@ -288,7 +288,7 @@ describe Publishable do
           extend Publishable
           publishable :on => :foobar
         end
-      }.to raise_error ActiveRecord::ConfigurationError
+      }.to_not raise_error
     end
 
   end


### PR DESCRIPTION
In this pull request I've changed the logic to NOT throw an exception if the `publishable` column doesn't exist.

I've found that throwing an exception in this case causes pain during migrations for models that are defined as `publishable` but for which the `publishable` column itself is created in a subsequent migration.
