### PR TITLE
Fixed bug in unpublish for Date/DateTime publishables.

### DIFF
--- a/lib/publishable.rb
+++ b/lib/publishable.rb
@@ -117,7 +117,7 @@ module Publishable
             end
 
             def unpublish()
-              self.#{column_name} = null
+              self.#{column_name} = nil
             end
 
             def unpublish!()
@@ -144,7 +144,7 @@ module Publishable
             end
 
             def unpublish()
-              self.#{column_name} = null
+              self.#{column_name} = nil
             end
 
             def unpublish!()
@@ -255,7 +255,7 @@ module Publishable
 
     # @!method unpublish
     #   Un-publish this object, i.e. set it to not be published.  For a Boolean publish field, the field is set to
-    #   false; for a Date/DateTime field, the field is set to null.
+    #   false; for a Date/DateTime field, the field is cleared.
     #   @!scope instance
 
     # @!method unpublish!

--- a/spec/publishable_spec.rb
+++ b/spec/publishable_spec.rb
@@ -78,6 +78,13 @@ describe Publishable do
       @post.published.should <= Date.current
     end
 
+    it 'can be unpublished' do
+      @post.published = Date.current
+      @post.should be_published
+      @post.unpublish!
+      @post.should_not be_published
+    end
+
   end
 
   context 'with a DateTime publish attribute' do
@@ -117,6 +124,13 @@ describe Publishable do
         @post.publish
         @post.should be_published
         @post.published.should <= DateTime.now
+      end
+
+      it 'can be unpublished' do
+        @post.published = DateTime.now - 1.minute
+        @post.should be_published
+        @post.unpublish!
+        @post.should_not be_published
       end
 
     end


### PR DESCRIPTION
In the `unpublish()` implementations for both `Date` and `DateTime` publish fields, the field was being cleared by setting it to `null`, when in fact it should have been set to `nil`.
